### PR TITLE
Validate the `signer` field in the JWT header

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,3 +44,6 @@ RSpec/ExampleLength:
 
 RSpec/MultipleExpectations:
   Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The plugin can be configured using the following environment variables:
 
 - `REDMINE_AMZN_ALB_AUTHN_KEY_ENDPOINT`
   - **(required)** Public key endpoint, e.g., `https://public-keys.auth.elb.ap-northeast-1.amazonaws.com` when the ALB is in the `ap-northeast-1` region.
+- `REDMINE_AMZN_ALB_AUTHN_ALB_ARN`
+  - **(required)** The ARN of the Application Load Balancer expected by the `signer` field in the JWT header.
 - `REDMINE_AMZN_ALB_AUTHN_ISS`
   - If set, the plugin will verify that the `iss` claim has the same value.
 

--- a/init.rb
+++ b/init.rb
@@ -12,6 +12,7 @@ Redmine::Plugin.register :redmine_amzn_alb_authn do
 end
 
 RedmineAmznAlbAuthn.key_endpoint = ENV.fetch('REDMINE_AMZN_ALB_AUTHN_KEY_ENDPOINT')
+RedmineAmznAlbAuthn.alb_arn = ENV.fetch('REDMINE_AMZN_ALB_AUTHN_ALB_ARN')
 RedmineAmznAlbAuthn.iss = ENV.fetch('REDMINE_AMZN_ALB_AUTHN_ISS', nil)
 
 ApplicationController.prepend(RedmineAmznAlbAuthn::ApplicationControllerPatch)

--- a/lib/redmine_amzn_alb_authn.rb
+++ b/lib/redmine_amzn_alb_authn.rb
@@ -6,5 +6,5 @@ require_relative 'redmine_amzn_alb_authn/application_controller_patch'
 
 # Plugin namespace and configuration store.
 module RedmineAmznAlbAuthn
-  mattr_accessor :key_endpoint, :iss
+  mattr_accessor :key_endpoint, :alb_arn, :iss
 end

--- a/lib/redmine_amzn_alb_authn/application_controller_patch.rb
+++ b/lib/redmine_amzn_alb_authn/application_controller_patch.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'errors'
 require_relative 'oidc_data_decoder'
 
 module RedmineAmznAlbAuthn
@@ -27,11 +28,12 @@ module RedmineAmznAlbAuthn
 
       decoder = OidcDataDecoder.new(
         key_endpoint: RedmineAmznAlbAuthn.key_endpoint,
+        alb_arn: RedmineAmznAlbAuthn.alb_arn,
         iss: RedmineAmznAlbAuthn.iss,
       )
       begin
         payload, _header = decoder.verify_and_decode!(amzn_oidc_data)
-      rescue JWT::DecodeError, Net::HTTPExceptions => e
+      rescue InvalidSignerError, JWT::DecodeError, Net::HTTPExceptions => e
         logger.error(e)
         return
       end

--- a/lib/redmine_amzn_alb_authn/errors.rb
+++ b/lib/redmine_amzn_alb_authn/errors.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module RedmineAmznAlbAuthn
+  Error = Class.new(StandardError)
+  InvalidSignerError = Class.new(Error)
+end

--- a/lib/redmine_amzn_alb_authn/oidc_data_decoder.rb
+++ b/lib/redmine_amzn_alb_authn/oidc_data_decoder.rb
@@ -7,18 +7,21 @@ require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/numeric/time'
 require 'jwt'
 
+require_relative 'errors'
+
 module RedmineAmznAlbAuthn
   # Verifies and decodes the JWT from the X-Amzn-Oidc-Data header sent by ALB.
   class OidcDataDecoder
     class_attribute :key_cache, default: ActiveSupport::Cache::MemoryStore.new(expires_in: 1.hour)
 
-    def initialize(key_endpoint:, iss: nil)
+    def initialize(key_endpoint:, alb_arn:, iss: nil)
       @key_endpoint = key_endpoint
+      @alb_arn = alb_arn
       @iss = iss
     end
 
     def verify_and_decode!(oidc_data)
-      JWT.decode(oidc_data, nil, true, algorithm: 'ES256', iss: @iss, verify_iss: true) do |header|
+      payload, header = JWT.decode(oidc_data, nil, true, algorithm: 'ES256', iss: @iss, verify_iss: true) do |header|
         key_str = key_cache.fetch(header.fetch('kid')) do
           key_uri = URI.join(@key_endpoint, header['kid'])
           key_response = Net::HTTP.get_response(key_uri)
@@ -27,6 +30,10 @@ module RedmineAmznAlbAuthn
         end
         OpenSSL::PKey::EC.new(key_str)
       end
+
+      raise InvalidSignerError, "Invalid signer: #{header['signer']}" if header['signer'] != @alb_arn
+
+      [payload, header]
     end
   end
 end


### PR DESCRIPTION
From https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html:

> To ensure security, you must verify the signature before doing any authorization based on the claims and validate that the signer field in the JWT header contains the expected Application Load Balancer ARN.

This PR implements this validation for the `signer` field in the JWT header.